### PR TITLE
Fix Contentful spelling in footer

### DIFF
--- a/src/views/Footer/Footer.js
+++ b/src/views/Footer/Footer.js
@@ -59,7 +59,7 @@ class Footer extends Component {
 
           <div className="footer-copy__wrapper">
             <p>
-              Site hand-crafted with VS Code, React JS, Sass, and Contenful API.
+              Site hand-crafted with VS Code, React JS, Sass, and Contentful API.
               <br />
               <small>Made in Seattle, WA.{" "}</small>
               <br />


### PR DESCRIPTION
## Summary
- fix a typo in footer text: `Contenful` -> `Contentful`

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_68630775208483218182d1371f7a6d8f