### PR TITLE
feat: integrate Tailwind CSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "sass": "^1.86.0",
     "sass-loader": "^7.3.1",
     "style-loader": "^0.13.2",
+    "tailwindcss": "^3.4.1",
     "url-loader": "^2.1.0",
     "webpack": "^4.47.0",
     "webpack-cli": "^3.3.12",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   plugins: [
+    require('tailwindcss'),
     require('postcss-flexbugs-fixes'),
     require('autoprefixer')({
       flexbox: 'no-2009'

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,3 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 @import "reset";
 @import "shared";
 @import "fonts";

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ["./src/**/*.{js,jsx,html}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -99,6 +99,7 @@ module.exports = {
         use: [
           "style-loader", // creates style nodes from JS strings
           "css-loader", // translates CSS into CommonJS
+          "postcss-loader", // processes CSS with PostCSS plugins
         ],
       },
 
@@ -108,6 +109,7 @@ module.exports = {
         use: [
           "style-loader", // creates style nodes from JS strings
           "css-loader", // translates CSS into CommonJS
+          "postcss-loader", // processes CSS with PostCSS plugins
           "sass-loader", // compiles Sass to CSS, using Node Sass by default
         ],
       },


### PR DESCRIPTION
## Summary
- add Tailwind CSS dependency and configuration
- process styles through PostCSS with Tailwind
- enable Tailwind directives in main stylesheet

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf79a7e18c8321a05a6515e1259e3a